### PR TITLE
Update links after GitHub org migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ clj-protocol enables declarative definition of network protocols and
 binary formats.
 
 Full API Documentation (generated with codox) is available
-[here](https://lonocloud.github.io/clj-protocol/www/index.html).
+[here](https://viasat.github.io/clj-protocol/www/index.html).
 
 clj-protocol is primarily designed for use in ClojureScript (due to
 stronger host networking interfaces), however, the core libraries also
@@ -191,7 +191,7 @@ If you are using Clojure (JVM) then run tests using leiningen:
 lein test
 ```
 
-Use docker-compose and [conlink](https://github.com/LonoCloud/conlink)
+Use docker-compose and [conlink](https://github.com/Viasat/conlink)
 to launch a self-contained network environment that runs the DHCP
 client, server, and ping client.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "clj-protocol",
   "version": "1.1.1",
   "description": "clj-protocol - Declarative protocol library",
-  "repository": "https://github.com/LonoCloud/clj-protocol",
+  "repository": "https://github.com/Viasat/clj-protocol",
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
     "koffi": "^2.9.0",

--- a/project.clj
+++ b/project.clj
@@ -18,4 +18,4 @@
    :doc-files ["docs/tutorial.md" "docs/examples.md"]
    :output-path "docs/www"
    :metadata {:doc/format :markdown}
-   :source-uri "http://github.com/LonoCloud/clj-protocol/blob/{git-commit}/{filepath}#L{line}"})
+   :source-uri "http://github.com/Viasat/clj-protocol/blob/{git-commit}/{filepath}#L{line}"})


### PR DESCRIPTION
Updates links after the LonoCloud-Viasat org migration, fixing the broken GitHub Pages link to the rendered docs.  I'm working on re-rendering the docs.